### PR TITLE
Introduce a better chexdump & hexdump

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+v0.5.0
+* Introduce a chexdump functionality (w/ show or ret str/list)
+
 v0.4.5
 * Introduce a batch of improvements. Automatically convert packages to hex format, show str[hex] object when assertion failed. Resolve a few bugs when used with Python 2.7. The clean message format for Python 2.7.
 

--- a/scapy_helper/chexdump.py
+++ b/scapy_helper/chexdump.py
@@ -1,0 +1,26 @@
+from scapy_helper.main import _prepare
+
+
+def chexdump(packet, dump=False, to_list=False):
+    """
+    Return a chexdump base on packet
+    :param packet: String or Scapy object
+    :param dump: True if you want to dump instead of print
+    :param to_list: True if you want a list of hex instead of a string
+    :return: None or Str or List
+    """
+    def _add_0x_before(p):
+        return ["0x%s" % x for x in p]
+
+    processed_packet = _prepare(packet)
+    if not processed_packet:
+        return
+
+    if dump:
+        if to_list:
+            return _add_0x_before(processed_packet)
+        else:
+            return ", ".join(_add_0x_before(processed_packet))
+    print(", ".join(_add_0x_before(processed_packet)))
+
+

--- a/scapy_helper/hexdump.py
+++ b/scapy_helper/hexdump.py
@@ -1,0 +1,2 @@
+def hexdump(packet, dump=False):
+    pass

--- a/scapy_helper/hexdump.py
+++ b/scapy_helper/hexdump.py
@@ -1,2 +1,37 @@
-def hexdump(packet, dump=False):
-    pass
+from scapy_helper.main import _prepare
+
+
+def hexdump(packet, dump=False, to_list=False):
+    def to_number(number):
+        return number if isinstance(number, int) else ord(number)
+
+    def to_char(string):
+        j = to_number(string)
+        if (j < 32) or (j >= 127):
+            return "."
+        else:
+            return string(j)
+
+    def split(obj, num):
+        return [obj[start:start + num]
+                for start in range(0, len(obj), num)
+                if obj[start:start + num]]
+
+    processed_packet = _prepare(packet)
+    if not processed_packet:
+        return
+
+    row = []
+    for i, line in enumerate(split(processed_packet, 16)):
+        console_char = [to_char(int(x, 16)) for x in line]
+
+        if len(line) < 16:
+            line += ["   " for _ in range(16 - len(line))]
+
+        row.append("%03x0   %s   %s" %
+                   (i, ' '.join(line), ''.join(console_char)))
+    if dump:
+        if to_list:
+            return row
+        return "\n".join(row).rstrip("\n")
+    print("\n".join(row).rstrip("\n"))

--- a/scapy_helper/hexdump.py
+++ b/scapy_helper/hexdump.py
@@ -10,7 +10,7 @@ def hexdump(packet, dump=False, to_list=False):
         if (j < 32) or (j >= 127):
             return "."
         else:
-            return string(j)
+            return chr(string)
 
     def split(obj, num):
         return [obj[start:start + num]

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     long_description_content_type="text/markdown",
     author="Nex Sabre",
     author_email="nexsabre@protonmail.com",
-    version="0.4.5",
+    version="0.5.0",
     url="https://github.com/NexSabre/scapy_helper",
     packages=find_packages(),
     classifiers=[

--- a/test/test_chexdump.py
+++ b/test/test_chexdump.py
@@ -5,7 +5,7 @@ from scapy.layers.l2 import Ether
 from scapy_helper.chexdump import chexdump
 
 
-class TestHexdump(unittest.TestCase):
+class TestcHexdump(unittest.TestCase):
     def setUp(self):
         self.packet = Ether(dst="ff:ff:ff:ff:ff:ff",
                             src="00:00:00:00:00:00")

--- a/test/test_chexdump.py
+++ b/test/test_chexdump.py
@@ -1,0 +1,27 @@
+import unittest
+
+from scapy.layers.l2 import Ether
+
+from scapy_helper.chexdump import chexdump
+
+
+class TestHexdump(unittest.TestCase):
+    def setUp(self):
+        self.packet = Ether(dst="ff:ff:ff:ff:ff:ff",
+                            src="00:00:00:00:00:00")
+
+    def test_chexdump_dump_true(self):
+        expected_result = '0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x90, 0x00'
+        result = chexdump(self.packet, dump=True)
+
+        self.assertIsInstance(result, str, "Dump should be a string")
+        self.assertEqual(expected_result, result, "Dump of the hex should be the same")
+
+    def test_chexdump_dump_true_as_list(self):
+        expected_result = ['0xff', '0xff', '0xff', '0xff', '0xff', '0xff',
+                           '0x00', '0x00', '0x00', '0x00', '0x00', '0x00',
+                           '0x90', '0x00']
+        result = chexdump(self.packet, dump=True, to_list=True)
+
+        self.assertIsInstance(result, list, "Dump should be a string")
+        self.assertEqual(result, expected_result, "Dump of the hex should be the same")

--- a/test/test_hexdump.py
+++ b/test/test_hexdump.py
@@ -1,0 +1,29 @@
+import unittest
+
+from scapy.layers.l2 import Ether
+
+from scapy_helper.hexdump import hexdump
+
+
+class TestHexdump(unittest.TestCase):
+    def setUp(self):
+        self.packet = Ether(dst="ff:ff:ff:ff:ff:ff",
+                            src="00:00:00:00:00:00")
+
+    def test_chexdump_dump_true(self):
+        # expected_result = '0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x90, 0x00'
+        # result = hexdump(self.packet, dump=True)
+        #
+        # self.assertIsInstance(result, str, "Dump should be a string")
+        # self.assertEqual(expected_result, result, "Dump of the hex should be the same")
+        pass
+
+    def test_chexdump_dump_true_as_list(self):
+        # expected_result = ['0xff', '0xff', '0xff', '0xff', '0xff', '0xff',
+        #                    '0x00', '0x00', '0x00', '0x00', '0x00', '0x00',
+        #                    '0x90', '0x00']
+        # result = hexdump(self.packet, dump=True)
+        #
+        # self.assertIsInstance(result, list, "Dump should be a string")
+        # self.assertEqual(result, expected_result, "Dump of the hex should be the same")
+        pass

--- a/test/test_hexdump.py
+++ b/test/test_hexdump.py
@@ -1,5 +1,6 @@
 import unittest
 
+from scapy.layers.inet import IP
 from scapy.layers.l2 import Ether
 
 from scapy_helper.hexdump import hexdump
@@ -8,22 +9,22 @@ from scapy_helper.hexdump import hexdump
 class TestHexdump(unittest.TestCase):
     def setUp(self):
         self.packet = Ether(dst="ff:ff:ff:ff:ff:ff",
-                            src="00:00:00:00:00:00")
+                            src="00:00:00:00:00:00") / IP()
 
-    def test_chexdump_dump_true(self):
-        # expected_result = '0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x90, 0x00'
-        # result = hexdump(self.packet, dump=True)
-        #
-        # self.assertIsInstance(result, str, "Dump should be a string")
-        # self.assertEqual(expected_result, result, "Dump of the hex should be the same")
-        pass
+    def test_hexdump_dump_true(self):
+        expected_result = "0000ffffffffffff00000000000008004500..............E." \
+                          "00100014000100004000fbe8000000007f00......@........." \
+                          "00200001.."
+        result = hexdump(self.packet, dump=True).replace(" ", "").replace("\n", "")
 
-    def test_chexdump_dump_true_as_list(self):
-        # expected_result = ['0xff', '0xff', '0xff', '0xff', '0xff', '0xff',
-        #                    '0x00', '0x00', '0x00', '0x00', '0x00', '0x00',
-        #                    '0x90', '0x00']
-        # result = hexdump(self.packet, dump=True)
-        #
-        # self.assertIsInstance(result, list, "Dump should be a string")
-        # self.assertEqual(result, expected_result, "Dump of the hex should be the same")
-        pass
+        self.assertIsInstance(result, str, "Dump should be a string")
+        self.assertEqual(expected_result, result, "Dump of the hex should be the same")
+
+    def test_hexdump_dump_true_as_list(self):
+        expected_result = ['0000ffffffffffff00000000000008004500..............E.',
+                           '00100014000100004000fbe8000000007f00......@.........',
+                           '00200001..']
+        result = [x.replace(" ", "").replace("\n", "") for x in hexdump(self.packet, dump=True, to_list=True)]
+
+        self.assertIsInstance(result, list, "Dump should be a list")
+        self.assertEqual(expected_result, result, "Dump of the hex should be the same")

--- a/test/test_hexdump.py
+++ b/test/test_hexdump.py
@@ -5,6 +5,8 @@ from scapy.layers.l2 import Ether
 
 from scapy_helper.hexdump import hexdump
 
+from scapy.utils import hexdump as scap_hexdump
+
 
 class TestHexdump(unittest.TestCase):
     def setUp(self):
@@ -26,25 +28,27 @@ class TestHexdump(unittest.TestCase):
         expected_result = ['0000ffffffffffff00000000000008004500..............E.',
                            '00100014000100004000fbe8000000007f00......@.........',
                            '00200001..']
-        result = [x.replace(" ", "").replace("\n", "") for x in hexdump(self.packet, dump=True, to_list=True)]
+        result = [x.replace(" ", "").replace("\n", "") for x in hexdump(self.packet_hex, dump=True, to_list=True)]
+
+        expected_result = [x.lower() for x in expected_result]
+        result = [x.lower() for x in result]
 
         self.assertIsInstance(result, list, "Dump should be a list")
         self.assertEqual(expected_result, result, "Dump of the hex should be the same")
 
     def test_hexdump_dump_true(self):
-        expected_result = "0000ffffffffffff00000000000008004500..............E." \
-                          "00100014000100004000fbe8000000007f00......@........." \
-                          "00200001.."
+        expected_result = scap_hexdump(self.packet, dump=True).replace(" ", "").replace("\n", "")
         result = hexdump(self.packet, dump=True).replace(" ", "").replace("\n", "")
 
         self.assertIsInstance(result, str, "Dump should be a string")
-        self.assertEqual(expected_result, result, "Dump of the hex should be the same")
+        self.assertEqual(expected_result.lower(), result.lower(), "Dump of the hex should be the same")
 
     def test_hexdump_dump_true_as_list(self):
-        expected_result = ['0000ffffffffffff00000000000008004500..............E.',
-                           '00100014000100004000fbe8000000007f00......@.........',
-                           '00200001..']
+        expected_result = scap_hexdump(self.packet, dump=True).replace(" ", "").split("\n")
         result = [x.replace(" ", "").replace("\n", "") for x in hexdump(self.packet, dump=True, to_list=True)]
+
+        expected_result = [x.lower() for x in expected_result]
+        result = [x.lower() for x in result]
 
         self.assertIsInstance(result, list, "Dump should be a list")
         self.assertEqual(expected_result, result, "Dump of the hex should be the same")

--- a/test/test_hexdump.py
+++ b/test/test_hexdump.py
@@ -10,6 +10,26 @@ class TestHexdump(unittest.TestCase):
     def setUp(self):
         self.packet = Ether(dst="ff:ff:ff:ff:ff:ff",
                             src="00:00:00:00:00:00") / IP()
+        self.packet_hex = "ff ff ff ff ff ff 00 00 00 00 00 00 08 00 " \
+                          "45 00 00 14 00 01 00 00 40 00 fb e8 00 00 " \
+                          "00 00 7f 00 00 01"
+
+    def test_hexdump_dump_from_string(self):
+        expected_result = '0000ffffffffffff00000000000008004500..............E.' \
+                          '00100014000100004000fbe8000000007f00......@.........' \
+                          '00200001..'
+        result = hexdump(self.packet_hex, dump=True).replace(" ", "").replace("\n", "")
+        hexdump(self.packet_hex)
+        self.assertEqual(expected_result, result, "String should be the same")
+
+    def test_hexdump_dump_from_string_as_list(self):
+        expected_result = ['0000ffffffffffff00000000000008004500..............E.',
+                           '00100014000100004000fbe8000000007f00......@.........',
+                           '00200001..']
+        result = [x.replace(" ", "").replace("\n", "") for x in hexdump(self.packet, dump=True, to_list=True)]
+
+        self.assertIsInstance(result, list, "Dump should be a list")
+        self.assertEqual(expected_result, result, "Dump of the hex should be the same")
 
     def test_hexdump_dump_true(self):
         expected_result = "0000ffffffffffff00000000000008004500..............E." \


### PR DESCRIPTION
chexdump
```python
result = chexdump(packet, dump=True, to_list=True)
# "["0xff", "0xff", "0xff", "0xff", "0xff", "0xff"]
```

hexdump
```python
packet_hex = "ff ff ff ff ff ff 00 00 00 00 00 00 08 00 " \
                      "45 00 00 14 00 01 00 00 40 00 fb e8 00 00 " \
                      "00 00 7f 00 00 01"
result = hexdump(packet_hex, dump=True, to_list=True)
# 
# 0000   ff ff ff ff ff ff 00 00 00 00 00 00 08 00 45 00   ..............E.
# 0010   00 14 00 01 00 00 40 00 fb e8 00 00 00 00 7f 00   ......@.........
# 0020   00 01                                                           ..
```