### PR TITLE
Add packet helper as better term for linters and imports 

### DIFF
--- a/packet_helper/__init__.py
+++ b/packet_helper/__init__.py
@@ -1,0 +1,6 @@
+from scapy_helper.main import get_hex, show_diff, show_hex, table, hex_equal
+from scapy_helper.hexdump import hexdump
+from scapy_helper.chexdump import chexdump
+from scapy_helper.compare import Compare
+
+from scapy_helper.test_case_extensions.packet_assert import PacketAssert

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     long_description_content_type="text/markdown",
     author="Nex Sabre",
     author_email="nexsabre@protonmail.com",
-    version="0.5.3",
+    version="0.6.0",
     url="https://github.com/NexSabre/scapy_helper",
     packages=find_packages(),
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Topic :: Software Development :: Libraries :: Python Modules",
     ],
     license='MIT',
     install_requires=["tabulate~=0.8.7"]


### PR DESCRIPTION
Few users raise an issue, that some tools raise false-positive alarms regarding the package's name. Scapy is on the GPL license, since the `scapy_helper` source code does not use any code from it, it can be published with the MIT license. 

__requirements.txt__
On pypi.org there's a new dummy package, which installs only the `scapy_helper` https://pypi.org/project/packet-helper/, so on the requirements.txt, you can store `packet-helper`. 

__usage at code__
With the `scapy_helper` version `0.6` there's also a dummy import, so in the code, you can import your favorite functions using `packate_helper` not a `scapy_helper` (if you care about linters and scanners).  


