### PR TITLE
Add assertion, handy shortcut for example Pytest's test

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+v0.13.0
+* Add assertion definitions: "assert_hex_equal", "assert_hex_not_equal", "assert_hex_len_equal", "assert_hex_len_not_equal",
+"assert_bytes_equal", "assert_bytes_not_equal"
+
 v0.12.1
 * Add more information to the hhstrip command
 

--- a/README.md
+++ b/README.md
@@ -204,6 +204,26 @@ int2ip(0)
 
 ## Test case usage
 
+### Use definition in Pytest
+You can use functions in your pytest (if you do not use a unittest or do not want to inherit by the `PacketAssert`)
+  * `assert_hex_equal`
+  * `assert_hex_not_equal`
+  * `assert_hex_len_equal` 
+  * `assert_hex_len_not_equal`
+  * `assert_bytes_equal`  
+  * `assert_bytes_not_equal`
+
+Example of usage:
+```python
+from scapy_helper import assert_hex_equal
+
+
+class TestExample:
+    def test_example(self):
+        assert_hex_equal(Ether(), Ether("10.10.10.10"))
+```
+
+
 ### Extends test class using PacketAssert (since v0.3.1)
 
 __Note: In the v0.3.0 this class was called HexEqual__
@@ -211,6 +231,7 @@ __Note: In the v0.3.0 this class was called HexEqual__
 You can use assertHexEqual/assertHexNotEqual and assertBytesEqual/assertBytesNotEqual in the tests. When the assertion
 fails, wrapper produces information about the frames (in hex).
 
+Example of usage: 
 ```python
 import unittest
 from scapy_helper.test_case_extensions.packet_assert import PacketAssert

--- a/scapy_helper/__init__.py
+++ b/scapy_helper/__init__.py
@@ -8,3 +8,5 @@ from scapy_helper.test_case_extensions.packet_assert import PacketAssert
 
 from scapy_helper.helpers.to_dict import to_dict
 from scapy_helper.helpers.to_list import to_list
+
+from scapy_helper.test_case_extensions.pytest_assert import *

--- a/scapy_helper/test_case_extensions/pytest_assert.py
+++ b/scapy_helper/test_case_extensions/pytest_assert.py
@@ -1,0 +1,25 @@
+from scapy_helper import PacketAssert
+
+
+def assert_hex_equal(first, second, message="Hex values are not equal"):
+    PacketAssert.assertHexEqual(first, second, message)
+
+
+def assert_hex_not_equal(first, second, message="Hex values are equal"):
+    PacketAssert.assertHexNotEqual(first, second, message)
+
+
+def assert_hex_len_equal(first, second, message="Hex len is equal"):
+    PacketAssert.assertHexLenEqual(first, second, message)
+
+
+def assert_hex_len_not_equal(first, second, message="Hex len is not equal"):
+    PacketAssert.assertHexLenNotEqual(first, second, message)
+
+
+def assert_bytes_equal(first, second, message="Bytes values are not equal"):
+    PacketAssert.assertBytesEqual(first, second, message)
+
+
+def assert_bytes_not_equal(first, second, message="Bytes values are eqaul"):
+    PacketAssert.assertBytesNotEqual(first, second, message)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     long_description_content_type="text/markdown",
     author="Nex Sabre",
     author_email="nexsabre@protonmail.com",
-    version="0.12.1",
+    version="0.13.0",
     url="https://github.com/NexSabre/scapy_helper",
     packages=find_packages(),
     classifiers=[

--- a/test/test_case_extensions/test_pytest_assert.py
+++ b/test/test_case_extensions/test_pytest_assert.py
@@ -1,0 +1,45 @@
+from unittest import TestCase
+
+from scapy_helper.test_case_extensions.pytest_assert import assert_hex_equal, assert_hex_not_equal, \
+    assert_hex_len_equal, assert_hex_len_not_equal
+
+DEFAULT_HEX = ("ff ff ff ff ff ff 00 00 00 00 00 00 08 00 45 00 00 "
+               "28 00 01 00 00 40 06 7c cd 7f 00 00 01 7f 00 00 01 "
+               "00 14 00 50 00 00 00 00 00 00 00 00 50 02 20 00 91 "
+               "7c 00 00")
+DIFFERENT_HEX = ("00 00 00 00 00 00 00 00 00 00 00 00 08 00 45 00 "
+                 "00 28 00 01 00 00 40 06 7c cd 7f 00 00 01 7f 00 "
+                 "00 01 00 14 00 50 00 00 00 00 00 00 00 00 50 02 "
+                 "20 00 91 7c 00 00")
+
+
+class TestPytestAssert(TestCase):
+    def test_assert_hex_equal(self):
+        assert_hex_equal(DEFAULT_HEX, DEFAULT_HEX)
+
+        with self.assertRaises(AssertionError):
+            assert_hex_equal(DEFAULT_HEX, DIFFERENT_HEX)
+
+    def test_assert_hex_not_equal(self):
+        assert_hex_not_equal(DEFAULT_HEX, DIFFERENT_HEX)
+
+        with self.assertRaises(AssertionError):
+            assert_hex_not_equal(DEFAULT_HEX, DEFAULT_HEX)
+
+    def test_assert_hex_len_equal(self):
+        assert_hex_len_equal(DEFAULT_HEX, DEFAULT_HEX)
+
+        with self.assertRaises(AssertionError):
+            assert_hex_len_equal(DEFAULT_HEX, DEFAULT_HEX[:len(DEFAULT_HEX) - 2])
+
+    def test_assert_hex_len_not_equal(self):
+        assert_hex_len_not_equal(DEFAULT_HEX, DEFAULT_HEX[:len(DEFAULT_HEX) - 2])
+
+        with self.assertRaises(AssertionError):
+            assert_hex_len_not_equal(DEFAULT_HEX, DEFAULT_HEX)
+
+    # def test_assert_bytes_equal(self):
+    #     self.fail()
+    #
+    # def test_assert_bytes_not_equal(self):
+    #     self.fail()

--- a/test/test_case_extensions/test_pytest_assert.py
+++ b/test/test_case_extensions/test_pytest_assert.py
@@ -1,16 +1,24 @@
 from unittest import TestCase
 
-from scapy_helper.test_case_extensions.pytest_assert import assert_hex_equal, assert_hex_not_equal, \
-    assert_hex_len_equal, assert_hex_len_not_equal
+from scapy_helper.test_case_extensions.pytest_assert import (
+    assert_hex_equal,
+    assert_hex_not_equal,
+    assert_hex_len_equal,
+    assert_hex_len_not_equal,
+)
 
-DEFAULT_HEX = ("ff ff ff ff ff ff 00 00 00 00 00 00 08 00 45 00 00 "
-               "28 00 01 00 00 40 06 7c cd 7f 00 00 01 7f 00 00 01 "
-               "00 14 00 50 00 00 00 00 00 00 00 00 50 02 20 00 91 "
-               "7c 00 00")
-DIFFERENT_HEX = ("00 00 00 00 00 00 00 00 00 00 00 00 08 00 45 00 "
-                 "00 28 00 01 00 00 40 06 7c cd 7f 00 00 01 7f 00 "
-                 "00 01 00 14 00 50 00 00 00 00 00 00 00 00 50 02 "
-                 "20 00 91 7c 00 00")
+DEFAULT_HEX = (
+    "ff ff ff ff ff ff 00 00 00 00 00 00 08 00 45 00 00 "
+    "28 00 01 00 00 40 06 7c cd 7f 00 00 01 7f 00 00 01 "
+    "00 14 00 50 00 00 00 00 00 00 00 00 50 02 20 00 91 "
+    "7c 00 00"
+)
+DIFFERENT_HEX = (
+    "00 00 00 00 00 00 00 00 00 00 00 00 08 00 45 00 "
+    "00 28 00 01 00 00 40 06 7c cd 7f 00 00 01 7f 00 "
+    "00 01 00 14 00 50 00 00 00 00 00 00 00 00 50 02 "
+    "20 00 91 7c 00 00"
+)
 
 
 class TestPytestAssert(TestCase):
@@ -30,10 +38,10 @@ class TestPytestAssert(TestCase):
         assert_hex_len_equal(DEFAULT_HEX, DEFAULT_HEX)
 
         with self.assertRaises(AssertionError):
-            assert_hex_len_equal(DEFAULT_HEX, DEFAULT_HEX[:len(DEFAULT_HEX) - 2])
+            assert_hex_len_equal(DEFAULT_HEX, DEFAULT_HEX[: len(DEFAULT_HEX) - 2])
 
     def test_assert_hex_len_not_equal(self):
-        assert_hex_len_not_equal(DEFAULT_HEX, DEFAULT_HEX[:len(DEFAULT_HEX) - 2])
+        assert_hex_len_not_equal(DEFAULT_HEX, DEFAULT_HEX[: len(DEFAULT_HEX) - 2])
 
         with self.assertRaises(AssertionError):
             assert_hex_len_not_equal(DEFAULT_HEX, DEFAULT_HEX)


### PR DESCRIPTION
### Use definition in Pytest
You can use functions in your pytest (if you do not use a unittest or do not want to inherit by the `PacketAssert`)
  * `assert_hex_equal`
  * `assert_hex_not_equal`
  * `assert_hex_len_equal` 
  * `assert_hex_len_not_equal`
  * `assert_bytes_equal`  
  * `assert_bytes_not_equal`

Example of usage:
```python
from scapy_helper import assert_hex_equal

